### PR TITLE
Support cimport usage

### DIFF
--- a/editdistance/__init__.pxd
+++ b/editdistance/__init__.pxd
@@ -1,0 +1,2 @@
+# cython: language_level=3
+from editdistance.bycython cimport eval

--- a/editdistance/bycython.pxd
+++ b/editdistance/bycython.pxd
@@ -1,0 +1,2 @@
+# cython: language_level=3
+cpdef unsigned int eval(object a, object b) except 0xffffffffffffffff

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ with open("README.rst") as readme_file:
 
 setup(
     name="editdistance",
-    version="0.6.1",
+    version="0.6.2",
     python_requires=">=3.6",
     description="Fast implementation of the edit distance(Levenshtein distance)",
     long_description=readme,

--- a/setup.py
+++ b/setup.py
@@ -21,15 +21,8 @@ except:
     from distutils import Extension, setup
 
 from Cython.Build import cythonize
-cythonize('editdistance/bycython.pyx')
 
-ext_modules = [
-    Extension(
-        "editdistance.bycython",
-        ["editdistance/_editdistance.cpp", "editdistance/bycython.cpp"],
-        include_dirs=["./editdistance"],
-    )
-]
+ext_modules = cythonize("editdistance/bycython.pyx")
 
 with open("README.rst") as readme_file:
     readme = readme_file.read()

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,9 @@ setup(
     url="https://www.github.com/roy-ht/editdistance",
     ext_modules=ext_modules,
     packages=["editdistance"],
-    package_data={"editdistance": ["_editdistance.h", "def.h"]},
+    package_data={
+        "editdistance": ["__init__.pxd", "_editdistance.h", "bycython.pxd", "def.h"]
+    },
     classifiers=[
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python",


### PR DESCRIPTION
This adds support for `cimport editdistance` from other Cython modules, which requires adding and bundling [pxd files](https://cython.readthedocs.io/en/latest/src/tutorial/pxd_files.html). I confirmed I was able to compile an external module that has a `cimport editdistance` with these changes.

I also adjusted the `setup.py` to use the `cythonize`d `ext_modules` rather than hard code them just to clean up a bit. Here's the difference between the hand created `Extension`'s `.__dict__` compared to the `cythonize` one (the `cythonize` one includes more metadata):
```diff
5c5
<     "include_dirs": ["./editdistance"],
---
>     "include_dirs": ["editdistance"],
16,17c16,17
<     "depends": [],
<     "language": None,
---
>     "depends": ["editdistance/_editdistance.h"],
>     "language": "c++",
18a19
>     "np_pythran": False,
```
