### PR TITLE
Fix pypi publish

### DIFF
--- a/.github/workflows/CI_CD_workflow.yml
+++ b/.github/workflows/CI_CD_workflow.yml
@@ -56,7 +56,7 @@ jobs:
       - name: setup build
         run: pip install build
       - name: Build sdist
-        run: ython -m build --sdist .
+        run: python -m build --sdist .
 
       - name: Download wheels
         uses: actions/download-artifact@v3


### PR DESCRIPTION
There's a small typo in the CI file during the sdist build, so this fixes that. I also confirmed that using `build`, even without `cython` installed, properly builds the sdist in an isolated env:

```
$ pip3 uninstall cython
WARNING: Skipping cython as it is not installed.

$ python -m build --sdist .
* Creating venv isolated environment...
* Installing packages in isolated environment... (Cython, setuptools, wheel)
* Getting build dependencies for sdist...
Compiling editdistance/bycython.pyx because it depends on /private/var/folders/ss/tgmzwbx52y35qpr7rzrtv8ym0000gn/T/build-env-2u3ii3ua/lib/python3.10/site-packages/Cython/Includes/libc/string.pxd.
[1/1] Cythonizing editdistance/bycython.pyx
running egg_info
writing editdistance.egg-info/PKG-INFO
writing dependency_links to editdistance.egg-info/dependency_links.txt
writing top-level names to editdistance.egg-info/top_level.txt
reading manifest file 'editdistance.egg-info/SOURCES.txt'
adding license file 'LICENSE'
writing manifest file 'editdistance.egg-info/SOURCES.txt'
* Building sdist...
running sdist
running egg_info
writing editdistance.egg-info/PKG-INFO
writing dependency_links to editdistance.egg-info/dependency_links.txt
writing top-level names to editdistance.egg-info/top_level.txt
reading manifest file 'editdistance.egg-info/SOURCES.txt'
adding license file 'LICENSE'
writing manifest file 'editdistance.egg-info/SOURCES.txt'
running check
creating editdistance-0.6.2
creating editdistance-0.6.2/editdistance
creating editdistance-0.6.2/editdistance.egg-info
creating editdistance-0.6.2/test
copying files to editdistance-0.6.2...
copying LICENSE -> editdistance-0.6.2
copying README.rst -> editdistance-0.6.2
copying pyproject.toml -> editdistance-0.6.2
copying setup.py -> editdistance-0.6.2
copying editdistance/__init__.pxd -> editdistance-0.6.2/editdistance
copying editdistance/__init__.py -> editdistance-0.6.2/editdistance
copying editdistance/_editdistance.cpp -> editdistance-0.6.2/editdistance
copying editdistance/_editdistance.h -> editdistance-0.6.2/editdistance
copying editdistance/bycython.cpp -> editdistance-0.6.2/editdistance
copying editdistance/bycython.pxd -> editdistance-0.6.2/editdistance
copying editdistance/def.h -> editdistance-0.6.2/editdistance
copying editdistance.egg-info/PKG-INFO -> editdistance-0.6.2/editdistance.egg-info
copying editdistance.egg-info/SOURCES.txt -> editdistance-0.6.2/editdistance.egg-info
copying editdistance.egg-info/dependency_links.txt -> editdistance-0.6.2/editdistance.egg-info
copying editdistance.egg-info/top_level.txt -> editdistance-0.6.2/editdistance.egg-info
copying test/test_editdistance.py -> editdistance-0.6.2/test
Writing editdistance-0.6.2/setup.cfg
Creating tar archive
removing 'editdistance-0.6.2' (and everything under it)
Successfully built editdistance-0.6.2.tar.gz
```
